### PR TITLE
Hyphenate category titles better. This is pretty silly.

### DIFF
--- a/giving/recipients/static/css/index.css
+++ b/giving/recipients/static/css/index.css
@@ -268,8 +268,10 @@ input[type="submit"].newsletter__button:active {
 }
 
 .categories__title {
-  hyphens: auto;
+  hyphens: none;
+  overflow: hidden;
   font-family: 'Titillium Web', sans-serif;
+  font-weight: 900;
   font-size: 36px;
   box-sizing: border-box;
   margin-bottom: 0.3rem;

--- a/giving/recipients/static/js/main.js
+++ b/giving/recipients/static/js/main.js
@@ -108,3 +108,74 @@
 })();
 
 
+(function() {
+  
+  function toArray(thing) {
+    return Array.prototype.slice.call(thing, 0);
+  }
+  
+  function hyphenatedWord(str) {
+    return '<span class="u-hyphens-allowed">' + str + '</span>';
+  }
+  
+  
+  function checkHyphenation(i, el) {
+    var $el = $(el);
+    if ( $el.has('span') ) {
+      $el.html( $el.text() );
+    }
+
+    var parentWidth = el.parentNode.offsetWidth;
+    if (el.offsetWidth <= parentWidth) { return; }
+    
+    var words = $el.text().split(/\s+/);
+    var rects = toArray( el.getClientRects() );
+    
+    var indices = [];
+    rects.forEach(function (rect, i) {
+      if (rect.width > parentWidth) {
+        indices.push(i);
+      }
+    });
+    
+    indices.forEach(function (i) {
+      words[i] = hyphenatedWord(words[i]);
+    });
+    
+    $el.html( words.join(' ') );
+  }
+  
+  
+  $(document).on('ready', function () {
+    var $catNames = $('.categories__title a');
+    if (!$catNames.length) { return; }
+    
+    $catNames.each(checkHyphenation);
+    listenForResize();
+  });
+  
+  function recheck() {
+    $('.categories__title p').each(checkHyphenation);
+    
+    var categoryNames = toArray( document.querySelectorAll('.categories__title a') );
+    categoryNames.each(checkHyphenation);
+    resizeTimeout = null;
+  }
+  
+  
+  function listenForResize() {
+    var resizeTimeout = null;
+  
+    window.addEventListener('resize', function () {
+      if (resizeTimeout) {
+        clearTimeout(resizeTimeout);
+        resizeTimeout = null;
+      }
+      setTimeout(recheck, 500);
+    });
+    
+  }
+  
+  
+  
+})();

--- a/giving/recipients/templates/recipients/index.html
+++ b/giving/recipients/templates/recipients/index.html
@@ -19,7 +19,7 @@
   <div class="categories__list">
     {% for cat in categories %}
     <section class="row categories__category">
-      <h2 class="categories__title six columns"><a href="/category/{{cat.name}}/">{{ cat.name }}</a></h2>
+      <h2 class="categories__title six columns"><a href="/category/{{cat.name}}/">{% mark_for_hyphenation cat.name %}</a></h2>
       
       <ul class="categories__org-list six columns">
         {% for r in cat.recipients %}

--- a/giving/recipients/templatetags/helpers.py
+++ b/giving/recipients/templatetags/helpers.py
@@ -1,6 +1,12 @@
 from django import template
 from django.utils.html import format_html
 
+import re
+import pyphen
+
+pyphen.language_fallback('en_US')
+dic = pyphen.Pyphen(lang='en_US')
+
 register = template.Library()
 
 @register.simple_tag
@@ -19,3 +25,21 @@ def link_to_recipient(r, classname=""):
 
   out += format_html(u"</span>")
   return out
+  
+
+@register.simple_tag
+def mark_for_hyphenation(text):
+  words = text.split(' ')
+  hyphenated_words = [choose_hyphens(word) for word in words]
+  return format_html( ' '.join(hyphenated_words) )
+  
+def choose_hyphens(word):
+  hyph = dic.inserted(word, '-')
+  # Remove the last hyphen unless there are at least 4 letters after it.
+  # Otherwise we get stuff like:
+  #       humanitari-
+  #       an
+  if (len(word) > 6) and (not re.search('-\\w{4,}$', hyph)):
+    hyph = re.sub('-(\\w+)$', '\\1', hyph)
+  
+  return re.sub('-', '&shy;', hyph)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests-oauthlib==0.7.0
 six==1.10.0
 tweepy==3.5.0
 wheel==0.24.0
+pyphen==0.9.4


### PR DESCRIPTION
The haphazard way that Chrome was hyphenating long category titles like “Humanitarian” bothered me because I’m basically a broken person. I pulled in a new library, changed the CSS, wrote another view helper, and added about 70 lines of JS to fix it.

You’re welcome to ignore this.